### PR TITLE
Replace Nerd font icons deprecated in version 3.0.0

### DIFF
--- a/lua/lsp-toggle/lsp.lua
+++ b/lua/lsp-toggle/lsp.lua
@@ -14,18 +14,18 @@ return {
 		local activeMap = {}
 		local list = vim.tbl_map(function(client)
 			activeMap[client.name] = true
-			return { text = ' ' .. client.name, client = client }
+			return { text = '󰄲 ' .. client.name, client = client }
 		end, clients)
 
 		local servers = lspconfig.util.available_servers()
 
-		if not activeMap['null-ls'] then list[#list + 1] = { text = ' null-ls', server = 'null-ls' } end
+		if not activeMap['null-ls'] then list[#list + 1] = { text = '󰄱 null-ls', server = 'null-ls' } end
 
 		for _, serverName in pairs(servers) do
 			if not activeMap[serverName] then
 				local server = lspconfig[serverName]
 				if (not server.filetypes) or vim.tbl_contains(server.filetypes, ft) then
-					list[#list + 1] = { text = ' ' .. serverName, server = server }
+					list[#list + 1] = { text = '󰄱 ' .. serverName, server = server }
 				end
 			end
 		end

--- a/lua/lsp-toggle/null-lsp.lua
+++ b/lua/lsp-toggle/null-lsp.lua
@@ -36,7 +36,7 @@ return {
 		-- }
 		for _, src in pairs(sources) do
 			if src.filetypes[ft] or src.filetypes._all then
-				local available = S.is_available(src, ft) and '' or ''
+				local available = S.is_available(src, ft) and '󰄲' or '󰄱'
 				local methods = vim.fn.join(vim.tbl_keys(src.methods), ',')
 				table.insert(results,
 					{ text = printf('%s %s (%s)', available, src.name, methods), src = src, ft = ft })


### PR DESCRIPTION
# Pull Request Template

## What Changed
The deprecated icons from the **nf-mdi-** class names have been replaced by the corresponding icons from the **nf-md-** class names.

## Motivation and Context
This is a fix for correct icons in the UI for users using the current version of Nerd Font.
[Nerd Font v3.0.0 Release (2023.04.30)](https://www.nerdfonts.com/releases#:~:text=Dropped%20codepoints%20F500%E2%80%A6%20and%20class%20names%20nf%2Dmdi%2D*)
Nerd Font >= v3.0.0 Release (2023.04.30) is required.

## Issues and links

## Type of change

- [ ] Bug Fix: non-breaking change which fixes an issue
- [ ] New Feature: non-breaking change which adds functionality
- [x] Bug Fix: breaking change which fixes an issue with deprecated Nerd Font icons in UI
- **Does it have breaking change?** Yes, update Nerd Font to the current version is required.

## Checklist

- [x] I have checked the [Checklist](./CONTRIBUTING.md#checklist-for-pull-request).
