### PR TITLE
none-ls support

### DIFF
--- a/lua/lsp-toggle/null-lsp.lua
+++ b/lua/lsp-toggle/null-lsp.lua
@@ -16,7 +16,7 @@ return {
 			local S = require('null-ls.sources')
 		end
 
-		if not nullLS then
+		if not nullLS_present then
 			print('Neither null-ls nor none-ls present')
 			return {}
 		end

--- a/lua/lsp-toggle/null-lsp.lua
+++ b/lua/lsp-toggle/null-lsp.lua
@@ -6,8 +6,21 @@ return {
 	desc = 'Disable/Enable NullLS source for all buffers',
 
 	command = function()
-		local nullLS = require('null-ls')
-		local S = require('null-ls.sources')
+		local nullLS_present, nullLS = pcall(require, 'null-ls')
+		if not nullLS_present then
+			nullLS_present, nullLS = pcall(require, 'none-ls')
+			if nullLS_present then
+				local S = require('none-ls.sources')
+			end
+		else
+			local S = require('null-ls.sources')
+		end
+
+		if not nullLS then
+			print('Neither null-ls nor none-ls present')
+			return {}
+		end
+
 		local sources = nullLS.get_sources()
 		local ft = vim.o.ft
 		local results = {}


### PR DESCRIPTION
# Pull Request Template

## What Changed
Add support for [none-ls](https://github.com/nvimtools/none-ls.nvim).

## Motivation and Context
[jose-elias-alvarez/null-ls.nvim](https://github.com/jose-elias-alvarez/null-ls.nvim) has been deprecated for over a year, with the new active fork being [nvimtools/none-ls.nvim](https://github.com/nvimtools/none-ls.nvim).

## Issues and links
None?

## Type of change
- [x] Bug Fix: non-breaking change which fixes an issue
- [x] New Feature: non-breaking change which adds functionality
- [ ] Other
- **Does it have breaking change?** No

## Checklist
<!-- Fill [x] means checked. -->

- [x] I have checked the [Checklist](./CONTRIBUTING.md#checklist-for-pull-request).
